### PR TITLE
Update to Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ using HackThatBase
 func(x,y) = x + y
 args = lminfo(func, (Int,Float64))   # (Int, Float64) are the types of x and y
 @hack W inference
-result = W.typeinf_uncached(args...)
+result = run_inference(W, args)
 ```
 
 After modifying `inference.jl`, simply re-run these steps to
@@ -22,19 +22,17 @@ execute the modified code:
 
 ```jl
 @hack W inference
-result = W.typeinf_uncached(args...)
+result = run_inference(W, args)
 ```
 
 To view the resulting inferred AST, use
 
 ```jl
-showast(args[1], result[1])
+showast(args[1], result[2])
 ```
 
-Some explanation:
-- `typeinf_uncached` is the (un-cached) entrypoint to type inference
-- `lminfo` is a helper function to extract the method signature
-   and other arguments to `typeinf`.
+`lminfo` is a helper function to extract the method signature
+and other arguments to `typeinf`.
 
 (on my system, the above steps take ~15 seconds to complete,
 as compared to >2 minutes to rebuild the second stage of sysimg)
@@ -59,11 +57,11 @@ julia> using HackThatBase
 julia> func(x,y) = x + y
 julia> args = lminfo(func, (Int,Float64))   # (Int, Float64) are the types of x and y
 julia> @hack W inference
-julia> result = W.typeinf_uncached(args...)
+julia> result = run_inference(W, args)
 julia> showast(args[1], result[1])
 shell> git stash pop   # restore your edited version of inference.jl
 julia> @hack W inference
-julia> result = W.typeinf_uncached(args...)
+julia> result = run_inference(W, args)
 ```
 
 At this point your breakpoints will be triggered.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.4-
-Compat
+julia 0.6.0-pre

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,14 +4,8 @@ using Base.Test
 func(x,y) = x + y
 args = lminfo(func, (Int, Float64))
 
-if VERSION >= v"0.5.0-dev+3977"
-    @eval begin   # needed for julia-0.4
-        #cd(joinpath(JULIA_HOME, "..", "..", "base"))
-        cd(splitdir(Base.find_source_file("inference.jl"))[1])
-        @hack W inference
-        result = W.typeinf_uncached(args...)
-        @test isa(result[1], LambdaInfo)
-        @test result[2] == Float64
-        @test result[3] == true
-    end
-end
+cd(splitdir(Base.find_source_file("inference.jl"))[1])
+@hack W inference
+result = run_inference(W, args)
+@test isa(result[2], CodeInfo)
+@test result[3] == Float64


### PR DESCRIPTION
This requires 0.6 as a minimum version. Not sure whether you want that, but since there were pretty big changes to inference in 0.6 that seemed most expedient.